### PR TITLE
Fix "On AP Connection" settings & Add "On AP Connection" settings for shop send & shop receive

### DIFF
--- a/items/items.json
+++ b/items/items.json
@@ -374,8 +374,8 @@
         "codes": "op_VT,settingVTGateOpen"
       },
       {
-        "img": "images/settings/settingVTGateBosses.png",
-        "codes": "op_VT,settingVTGateBosses",
+        "img": "images/settings/settingVTGateBoth.png",
+        "codes": "op_VT,settingVTGateBoth",
         "inherit_codes": false
       },
       {
@@ -384,8 +384,8 @@
         "inherit_codes": false
       },
       {
-        "img": "images/settings/settingVTGateBoth.png",
-        "codes": "op_VT,settingVTGateBoth",
+        "img": "images/settings/settingVTGateBosses.png",
+        "codes": "op_VT,settingVTGateBosses",
         "inherit_codes": false
       }
     ]
@@ -453,13 +453,18 @@
         "codes": "op_SS,settingShopShuffleOff"
       },
       {
-        "img": "images/settings/shopShuffleSlot.png",
-        "codes": "op_SS,settingShopShuffleSlot,shopShuffle",
+        "img": "images/settings/shopShuffleType.png",
+        "codes": "op_SS,settingShopShuffleType,shopShuffle",
         "inherit_codes": false
       },
       {
         "img": "images/settings/shopShuffleType.png",
         "codes": "op_SS,settingShopShuffleType,shopShuffle",
+        "inherit_codes": false
+      },
+      {
+        "img": "images/settings/shopShuffleSlot.png",
+        "codes": "op_SS,settingShopShuffleSlot,shopShuffle",
         "inherit_codes": false
       }
       
@@ -477,13 +482,13 @@
         "codes": "op_SR,settingShopReceiveOff"
       },
       {
-        "img": "images/settings/shopReceiveShops.png",
-        "codes": "op_SR,settingShopReceiveShops",
+        "img": "images/settings/shopReceiveTypes.png",
+        "codes": "op_SR,settingShopReceiveTypes",
         "inherit_codes": false
       },
       {
-        "img": "images/settings/shopReceiveTypes.png",
-        "codes": "op_SR,settingShopReceiveTypes",
+        "img": "images/settings/shopReceiveShops.png",
+        "codes": "op_SR,settingShopReceiveShops",
         "inherit_codes": false
       },
       {

--- a/locations/fajroTemple.json
+++ b/locations/fajroTemple.json
@@ -31,7 +31,7 @@
                         ],
                         "access_rules": 
                         [
-                            "$newLock|3235824208"
+                            "$newLock|3235824224"
                         ],
                         "item_count": 1
                     }
@@ -717,7 +717,7 @@
                         ],
                         "access_rules": 
                         [
-                            "$newLock|3235824224"
+                            "$newLock|3235824208"
                         ],
                         "item_count": 1
                     }

--- a/scripts/autotracking/archipelago.lua
+++ b/scripts/autotracking/archipelago.lua
@@ -91,6 +91,44 @@ function onClear(slot_data)
         return
     end
 
+    if slot_data['options']['shopSendMode'] then
+        local obj = Tracker:FindObjectForCode("op_SS")
+        if obj then
+            if slot_data['options']['shopSendMode'] == "itemType" then
+                obj.CurrentStage = 1
+            elseif slot_data['options']['shopSendMode'] == "slot" then
+                obj.CurrentStage = 3
+            else
+                obj.CurrentStage = 0
+            end
+        end
+    else
+        local obj = Tracker:FindObjectForCode("op_SS")
+        if obj then
+            obj.CurrentStage = 0
+        end
+    end
+
+    if slot_data['options']['shopSendMode'] then
+        local obj = Tracker:FindObjectForCode("op_SR")
+        if obj then
+            if slot_data['options']['shopSendMode'] == "itemType" then
+                obj.CurrentStage = 1
+            elseif slot_data['options']['shopSendMode'] == "shop" then
+                obj.CurrentStage = 2
+            elseif slot_data['options']['shopSendMode'] == "slot" then
+                obj.CurrentStage = 3
+            else
+                obj.CurrentStage = 0
+            end
+        end
+    else
+        local obj = Tracker:FindObjectForCode("op_SR")
+        if obj then
+            obj.CurrentStage = 0
+        end
+    end
+
     if slot_data['options']['vtShadeLock'] then
         local obj = Tracker:FindObjectForCode("op_VT")
         if obj then
@@ -114,22 +152,22 @@ function onClear(slot_data)
     end
 
     if slot_data['options']["keyrings"] then 
-    Tracker:FindObjectForCode("op_KR").CurrentStage = 1
-        else
         Tracker:FindObjectForCode("op_KR").CurrentStage = 0
+    else
+        Tracker:FindObjectForCode("op_KR").CurrentStage = 1
     end
 
     if slot_data['options']["meteorPassage"] then 
-    Tracker:FindObjectForCode("op_VW").CurrentStage = 1
-        else
+        Tracker:FindObjectForCode("op_VW").CurrentStage = 1
+    else
         Tracker:FindObjectForCode("op_VW").CurrentStage = 0
     end
 
     if slot_data['options']["chestClearanceLevels"] then 
         Tracker:FindObjectForCode("op_CL").CurrentStage = 1
-            else
-            Tracker:FindObjectForCode("op_CL").CurrentStage = 0
-        end
+    else
+        Tracker:FindObjectForCode("op_CL").CurrentStage = 0
+    end
 end
 
 -- called when an item gets collected

--- a/scripts/autotracking/archipelago.lua
+++ b/scripts/autotracking/archipelago.lua
@@ -109,14 +109,14 @@ function onClear(slot_data)
         end
     end
 
-    if slot_data['options']['shopSendMode'] then
+    if slot_data['options']['shopReceiveMode'] then
         local obj = Tracker:FindObjectForCode("op_SR")
         if obj then
-            if slot_data['options']['shopSendMode'] == "itemType" then
+            if slot_data['options']['shopReceiveMode'] == "itemType" then
                 obj.CurrentStage = 1
-            elseif slot_data['options']['shopSendMode'] == "shop" then
+            elseif slot_data['options']['shopReceiveMode'] == "shop" then
                 obj.CurrentStage = 2
-            elseif slot_data['options']['shopSendMode'] == "slot" then
+            elseif slot_data['options']['shopReceiveMode'] == "slot" then
                 obj.CurrentStage = 3
             else
                 obj.CurrentStage = 0

--- a/scripts/autotracking/archipelago.lua
+++ b/scripts/autotracking/archipelago.lua
@@ -152,9 +152,13 @@ function onClear(slot_data)
     end
 
     if slot_data['options']["keyrings"] then 
-        Tracker:FindObjectForCode("op_KR").CurrentStage = 0
+        if slot_data['options']["keyrings"][0] then 
+            Tracker:FindObjectForCode("op_KR").CurrentStage = 1
+        else
+            Tracker:FindObjectForCode("op_KR").CurrentStage = 0
+        end
     else
-        Tracker:FindObjectForCode("op_KR").CurrentStage = 1
+        Tracker:FindObjectForCode("op_KR").CurrentStage = 0
     end
 
     if slot_data['options']["meteorPassage"] then 

--- a/scripts/autotracking/location_mapping.lua
+++ b/scripts/autotracking/location_mapping.lua
@@ -832,8 +832,8 @@ LOCATION_MAPPING =
 [3235824784] = {"@Vermillion Wasteland/Vermillion Wasteland - Weapon & Item Shop/Rice Cracker Slot - 200 Credits"},
 [3235824785] = {"@Vermillion Wasteland/Vermillion Wasteland - Weapon & Item Shop/Veggie Sticks Slot - 200 Credits"},
 -- Rhombus Weapons Cobalt Gear
--- [3235824786] = {"@Rhombus Square/Rhombus Square - Weapon Shop/Cobalt Goggles Slot - 71350 Credits"},
--- [3235824787] = {"@Rhombus Square/Rhombus Square - Weapon Shop/Cobalt Edge Slot - 70975 Credits"},
--- [3235824788] = {"@Rhombus Square/Rhombus Square - Weapon Shop/Cobalt Mail Slot - 71925 Credits"},
--- [3235824789] = {"@Rhombus Square/Rhombus Square - Weapon Shop/Cobalt Boots Slot - 71350 Credits"},
+[3235824786] = {"@Rhombus Square/Rhombus Square - Weapon Shop/Cobalt Goggles Slot - 71350 Credits"},
+[3235824787] = {"@Rhombus Square/Rhombus Square - Weapon Shop/Cobalt Edge Slot - 70975 Credits"},
+[3235824788] = {"@Rhombus Square/Rhombus Square - Weapon Shop/Cobalt Mail Slot - 71925 Credits"},
+[3235824789] = {"@Rhombus Square/Rhombus Square - Weapon Shop/Cobalt Boots Slot - 71350 Credits"}
 }


### PR DESCRIPTION
1. Fix VT Gate setting when connecting to AP server
2. Fix Dungeon Keyrings setting when connecting to AP server
3. Add automatic setting for Shop Shuffle Sending when connecting to AP server
4. Add automatic setting for Shop Shuffle Receive when connecting to AP server
5. Fix Cobalt Gear in Rhombus Square's Weapon Shop not clearing when acquired
6. Fix ID missmatch for "Faj"ro Temple GF - Right Chamber 1 Chest" and "Faj'ro Temple 1F - Right Chamber 1 Chest"